### PR TITLE
add string xml loading

### DIFF
--- a/robohive/physics/mj_sim_scene.py
+++ b/robohive/physics/mj_sim_scene.py
@@ -37,6 +37,8 @@ class DMSimScene(SimScene):
         if isinstance(model_handle, str):
             if model_handle.endswith('.xml'):
                 sim = dm_mujoco.Physics.from_xml_path(model_handle)
+            elif "<mujoco" in model_handle:
+                            sim = dm_mujoco.Physics.from_xml_string(model_handle)
             else:
                 sim = dm_mujoco.Physics.from_binary_path(model_handle)
         else:


### PR DESCRIPTION
If there's a more robust way of checking if the model_handle is an xml_string, can use that instead.