### PR TITLE
BUGFIX: RENDERER: Revert depth mapping method from mjDEPTH_ZERONEAR to mjDEPTH_ZEROFAR

### DIFF
--- a/robohive/renderer/mj_renderer.py
+++ b/robohive/renderer/mj_renderer.py
@@ -112,9 +112,6 @@ class MJRenderer(Renderer):
             rgb_arr = self._renderer.render()
         if depth:
             self._renderer.enable_depth_rendering()
-            # Remove the following WARNING:absl:ARB_clip_control unavailable while mjDEPTH_ZEROFAR requested, depth accuracy will be limited
-            # TODO: When this feature stabalizes in mujoco, switch back to mjDEPTH_ZEROFAR for better accuracy
-            self._renderer._mjr_context.readDepthMap = mujoco.mjtDepthMap.mjDEPTH_ZERONEAR
             self._renderer.update_scene(self._sim.data.ptr, camera=camera_id, scene_option=self._scene_option)
             dpt_arr = self._renderer.render()
             dpt_arr = dpt_arr[::-1, :]


### PR DESCRIPTION
Following the discussion in #132 .

Revert "BUGFIX: Depth rendering was throwing lots of warnings. Defaulting it back to the previous versions. This should be undone in the future when this feature is stable"

This reverts commit ae51c9e158c4cc6643cc7470e6979fa92408f873.

**NOTE**: Depth is still flipped in this commit, that issue is handled in #133 