### PR TITLE
fix(robot): index actuator qpos reads with jnt_qposadr, not jnt_dofadr

### DIFF
--- a/robohive/robot/robot.py
+++ b/robohive/robot/robot.py
@@ -365,7 +365,10 @@ class Robot():
                 actuator_trnid = sim.model.actuator_trnid[actuator['sim_id'], 0]
                 if actuator_trntype == mujoco.mjtTrn.mjTRN_JOINT:  # // force on joint
                     actuator['data_type'] = 'qpos'
-                    actuator['data_id'] = sim.model.jnt_dofadr[actuator_trnid]
+                    # qpos is indexed by jnt_qposadr, not jnt_dofadr; the two
+                    # diverge when a free/ball joint precedes this joint
+                    # (freejoint: 7 qpos vs 6 dofs), shifting every read.
+                    actuator['data_id'] = sim.model.jnt_qposadr[actuator_trnid]
                 elif actuator_trntype == mujoco.mjtTrn.mjTRN_TENDON:  # force on tendon
                     actuator['data_type'] = 'ten_length'
                     actuator['data_id'] = actuator_trnid


### PR DESCRIPTION
## Bug

`Robot._resolve_data_ids` caches each joint actuator's feedback address (`data_id`) into `sim.data.qpos`, but computes it with `jnt_dofadr` — the **qvel** address space. The two address spaces coincide only while every preceding joint is 1-DOF: any free/ball joint earlier in the model shifts every subsequent actuator's qpos read by the qpos/qvel size difference (freejoint: 7 qpos vs 6 dofs).

The stale read feeds the velocity limiter in `process_actuator()`, which re-anchors each command to the *wrong joint's* position — in practice the arm freezes at whatever pose keeps the misread error small, silently ignoring position targets.

## Repro

Observed on anthrohive `URDtriosPickPlace-v0`, where a manipulable box (freejoint) is defined before the UR5e: the arm ignored all position targets until this fix. Any model that places a freejoint body ahead of the actuated kinematic chain hits the same shift.

## Fix

One-line change: use `jnt_qposadr[actuator_trnid]` for the `qpos` `data_id`. Models with only 1-DOF joints (or with the robot defined first) are byte-for-byte unaffected, since the two tables agree there.

Note: this is independent of the `fix_act_id_indexing` branch (act_id vs sim_id remapping in `normalize_actions`) — different bug, no overlapping lines.
