### PR TITLE
BUGFIX: Better handling of x-axis when keys are empty

### DIFF
--- a/robohive/utils/paths_utils.py
+++ b/robohive/utils/paths_utils.py
@@ -274,14 +274,6 @@ def plot(path_handle, env_handle=None, output_dir=None, output_name='', env_args
             ax.set_xlim(time[0], time[-1])
             if iplt1 != (nplt1 - 1):
                 ax.axes.xaxis.set_ticklabels([])
-            if iplt1 == 0:
-                plt.title('Observations')
-            ax.yaxis.tick_right()
-            if path['env_infos']['obs_dict'][key].ndim<3:
-                plt.plot(
-                    path['env_infos']['time'],
-                    path['env_infos']['obs_dict'][key],
-                    label=key)
             # plt.ylabel(key)
             plt.text(0.01, .01, f"{key}{path['env_infos']['obs_dict'][key].shape}", transform=ax.transAxes)
         plt.xlabel('time (sec)')


### PR DESCRIPTION
## Summary
- Recovers a bugfix commit that was left behind on the old extend_supported_sensors branch and never made it into dev.
- Removes leftover dead/duplicate plotting code in paths_utils.py plot() (title/tick_right/plot block) that predates dev's later refactor of the same function and was never cleaned up there.

## Test plan
- [ ] Sanity-check plot() output on a sample rollout to confirm the x-axis/title rendering is unaffected.
